### PR TITLE
Fix various bugs & changes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,4 +40,7 @@
 dependencies {
     api("codechicken:codechickenlib:3.2.3.358")
     api rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:5519022")
+
+    // only used to debug texture maps
+    implementation rfg.deobf("curse.maven:groovyscript-687577:5789690")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup = vfyjxf.gregicprobe
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 1.3.1
+modVersion = 1.3.2
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = false
@@ -65,7 +65,7 @@ coreModClass =
 containsMixinsAndOrCoreModOnly = false
 
 # Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
-forceEnableMixins = false
+forceEnableMixins = true
 
 # Outputs pre-transformed and post-transformed loaded classes to run/CLASSLOADER_TEMP. Can be used in combination with
 # diff to see exactly what your ASM or Mixins are changing in the target file.

--- a/src/main/java/vfyjxf/gregicprobe/GregicProbe.java
+++ b/src/main/java/vfyjxf/gregicprobe/GregicProbe.java
@@ -7,6 +7,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.relauncher.Side;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import vfyjxf.gregicprobe.config.GregicProbeConfig;
@@ -29,7 +30,7 @@ import java.io.File;
 public class GregicProbe {
     public static Configuration config;
 
-    public static Logger logger = LogManager.getLogger(Tags.MODNAME );
+    public static Logger logger = LogManager.getLogger(Tags.MODNAME);
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event){

--- a/src/main/java/vfyjxf/gregicprobe/config/GregicProbeConfig.java
+++ b/src/main/java/vfyjxf/gregicprobe/config/GregicProbeConfig.java
@@ -45,39 +45,5 @@ public class GregicProbeConfig {
         }
     }
 
-    @SubscribeEvent
-    public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
-        if (GregicProbe.MODID.equals(event.getModID())) {
-            ConfigManager.sync(GregicProbe.MODID, Config.Type.INSTANCE);
-        }
-    }
-
-    // to be used (eventually)
-    public static Map<String, Integer> getValues(Configuration config) {
-        Map<String, Integer> values = new HashMap<>();
-        for (Map.Entry<String, Property> entry : config.getCategory("general").entrySet()) {
-            Property prop = entry.getValue();
-            switch (entry.getValue().getType()) {
-                case BOOLEAN: {
-                    values.put(entry.getKey(), prop.getBoolean() ? 1 : 0);
-                }
-                case INTEGER: {
-                    values.put(entry.getKey(), prop.getInt());
-                }
-                case STRING: {
-                    for (int i = 0; i < prop.getValidValues().length; i++) {
-                        if (prop.getValidValues()[i].equals(prop.getString())) {
-                            values.put(entry.getKey(), i);
-                        }
-                    }
-                }
-                default: {
-                    values.put(entry.getKey(), entry.getValue().getInt());
-                }
-            }
-        }
-
-        return values;
-    }
 
 }

--- a/src/main/java/vfyjxf/gregicprobe/config/GregicProbeGuiFactory.java
+++ b/src/main/java/vfyjxf/gregicprobe/config/GregicProbeGuiFactory.java
@@ -7,6 +7,7 @@ import net.minecraftforge.fml.client.IModGuiFactory;
 import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import vfyjxf.gregicprobe.GregicProbe;
+import vfyjxf.gregicprobe.Tags;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,7 @@ public class GregicProbeGuiFactory implements IModGuiFactory {
 
     @Override
     public GuiScreen createConfigGui(GuiScreen parentScreen) {
-        return new GuiConfig(parentScreen, getConfigElements(), GregicProbe.MODID, false, false, GregicProbe.NAME);
+        return new GuiConfig(parentScreen, getConfigElements(), Tags.MODID, false, false, Tags.MODNAME);
     }
 
     @Override

--- a/src/main/java/vfyjxf/gregicprobe/element/FluidStackElement.java
+++ b/src/main/java/vfyjxf/gregicprobe/element/FluidStackElement.java
@@ -59,8 +59,16 @@ public class FluidStackElement implements IElement {
 
     @Override
     public void render(int x, int y) {
+        String actualLocation = location;
+
+        // Gregtech fluids added by GRS do this for some reason
+        // As a consequence the fluid texture from /dull will not show up on anything from GRS.
+        if (location.contains("material_sets/fluid/") && (location.contains("/gas") || location.contains("/plasma"))) {
+            actualLocation = location.replace("material_sets/fluid/", "material_sets/dull/");
+        }
+
         if (sprite == null) {
-            sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(location);
+            sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(actualLocation);
         }
 
         GlStateManager.enableBlend();

--- a/src/main/java/vfyjxf/gregicprobe/integration/gregtech/RecipeFluidOutputInfoProvider.java
+++ b/src/main/java/vfyjxf/gregicprobe/integration/gregtech/RecipeFluidOutputInfoProvider.java
@@ -3,6 +3,9 @@ package vfyjxf.gregicprobe.integration.gregtech;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
+import gregtech.api.fluids.GTFluid;
+import gregtech.api.util.GTUtility;
+import gregtech.api.util.LocalizationUtils;
 import gregtech.integration.theoneprobe.provider.CapabilityInfoProvider;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeHitData;
@@ -16,6 +19,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import org.jetbrains.annotations.Nullable;
 import vfyjxf.gregicprobe.config.GregicProbeConfig;
 import vfyjxf.gregicprobe.element.ElementSync;
 import vfyjxf.gregicprobe.element.FluidStackElement;
@@ -27,6 +31,7 @@ public class RecipeFluidOutputInfoProvider extends CapabilityInfoProvider<IWorka
     public RecipeFluidOutputInfoProvider() {
 
     }
+
 
     @Override
     protected Capability<IWorkable> getCapability() {
@@ -41,13 +46,21 @@ public class RecipeFluidOutputInfoProvider extends CapabilityInfoProvider<IWorka
             if (!fluidOutputs.isEmpty()) {
                 horizontalPane.text(TextStyleClass.INFO + "{*gregicprobe.top.fluid.outputs*} ");
 
+                int fluidsToDisplay = 2;
+                if (player.isSneaking()) fluidsToDisplay = 6;
+
+                int index = -1;
                 for (FluidStack fluidOutput : fluidOutputs) {
                     if (fluidOutput != null && fluidOutput.amount > 0) {
+
+                        index++;
+
+                        if (index % 2 == 0 && fluidOutputs.size() <= fluidsToDisplay && fluidOutputs.size() >= 2) horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
 
                         if (GregicProbeConfig.displayBukkit || !GregicProbeConfig.displayFluidName)
                             horizontalPane.element(new FluidStackElement(ElementSync.getElementId("fluid_stack"), fluidOutput, GregicProbeConfig.displayFluidQuantities));
 
-                        if ((!GregicProbeConfig.displayFluidName || fluidOutputs.size() > 2) && !GregicProbeConfig.displayFluidQuantities) {
+                        if ((!GregicProbeConfig.displayFluidName || fluidOutputs.size() > fluidsToDisplay) && !GregicProbeConfig.displayFluidQuantities) {
                             if (fluidOutput.amount >= 1000) {
                                 horizontalPane.text(TextStyleClass.INFO + " * " + (fluidOutput.amount / 1000) + "B");
                             } else {
@@ -55,12 +68,11 @@ public class RecipeFluidOutputInfoProvider extends CapabilityInfoProvider<IWorka
                             }
                         }
 
-                        if (GregicProbeConfig.displayFluidName && fluidOutputs.size() <= 2 && !GregicProbeConfig.displayFluidQuantities) {
+                        if (GregicProbeConfig.displayFluidName && fluidOutputs.size() <= fluidsToDisplay && !GregicProbeConfig.displayFluidQuantities) {
                             horizontalPane.text(TextStyleClass.INFO + " {*" + fluidOutput.getLocalizedName() + "*}" + " * " + fluidOutput.amount + "mb ");
-                        } else if (GregicProbeConfig.displayFluidQuantities && fluidOutputs.size() <= 2) {
-                            horizontalPane.text(TextStyleClass.INFO + " {*" + fluidOutput.getLocalizedName() + "*}");
+                        } else if (GregicProbeConfig.displayFluidQuantities && fluidOutputs.size() <= fluidsToDisplay) {
+                                horizontalPane.text(TextStyleClass.INFO + " {*" + fluidOutput.getLocalizedName() + "*} ");
                         }
-
                     }
                 }
             }

--- a/src/main/resources/assets/gregicprobe/lang/en_us.lang
+++ b/src/main/resources/assets/gregicprobe/lang/en_us.lang
@@ -1,4 +1,4 @@
 gregicprobe:top.eut=EUt:
 gregicprobe:top.item.outputs=Item Crafting:
 gregicprobe.top.fluid.outputs=Fluid Crafting:
-gregicprobe.top.pipe.energy=Avg. Energy: §a%s EU/t §f(%s§f) @ §a%sA
+gregicprobe.top.pipe.energy=Avg. Energy: §a%s EU/t §f(%s§f/%s§f) @ §a%s§f/§a%s A

--- a/src/main/resources/assets/gregicprobe/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregicprobe/lang/zh_cn.lang
@@ -1,4 +1,4 @@
 gregicprobe:top.eut=EUt:
 gregicprobe:top.item.outputs=物品制作中:
 gregicprobe.top.fluid.outputs=流体制作中:
-gregicprobe.top.pipe.energy=平均能流: §a%s EU/t §f(%s§f) @ §a%sA
+gregicprobe.top.pipe.energy=平均能流: §a%s EU/t §f(%s§f/%s§f) @ §a%s§f/§a%s A


### PR DESCRIPTION

# What

### Fixes the following issues:
1. cable information in TOP was broken on servers
2. GT fluids from materials added by GRS showed as missing textures
3. cable display information wasn't accurate (still isn't but it should be better)
4. cable always displayed the voltage tier as the cable's max voltage

### Adds some changes:
1. Holding shift while looking at a machine that has fluid outputs will expand it. (this has a limit of 6 fluids compared to 2)
2. Cables now show current voltage tier passing through it, along with the max voltage tier it can transport, along with that it shows the max amperage alongside the current amperage.
